### PR TITLE
Fix: Update Spelling, Format Text, and Remove Image Keyword for Eslint Compliance

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -6,7 +6,7 @@ const Contact = () => {
         <form method='POST' action="https://getform.io/f/a699a1b2-f225-434e-b317-1fbbde8e006c" className='flex flex-col max-w-[600px] w-full'>
             <div className='pb-8'>
                 <p className='text-4xl font-bold inline border-b-4 border-pink-600 text-gray-300'>Contact</p>
-                <p className='text-gray-300 py-4'>// Submit the form below or shoot me an email - vutukuri.kumar192st.niituniversity.in</p>
+                <p className='text-gray-300 py-4'>{"// Submit the form below or shoot me an email - vutukuri.kumar192st.niituniversity.in"}</p>
             </div>
             <input className='bg-[#ccd6f6] p-2' type="text" placeholder='Name' name='name' />
             <input className='my-4 p-2 bg-[#ccd6f6]' type="email" placeholder='Email' name='email' />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -19,7 +19,7 @@ const Navbar = () => {
   return (
     <div className='fixed w-full h-[80px] flex justify-between items-center px-4 bg-[#0a192f] text-gray-300'>
       <div>
-        <img src={Logo} alt='Logo Image' style={{ width: '200px' }} />
+        <img src={Logo} alt='Logo' style={{ width: '200px' }} />
       </div>
 
       {/* menu */}

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -17,7 +17,7 @@ const Skills = () => {
       <div className='max-w-[1000px] mx-auto p-4 flex flex-col justify-center w-full h-full'>
           <div>
               <p className='text-4xl font-bold inline border-b-4 border-pink-600 '>Skills</p>
-              <p className='py-4'>// These are the technologies I've worked with</p>
+              <p className='py-4'>{"// These are the technologies I've worked with"}</p>
           </div>
 
           <div className='w-full grid grid-cols-2 sm:grid-cols-4 gap-4 text-center py-8'>

--- a/src/components/Work.jsx
+++ b/src/components/Work.jsx
@@ -15,13 +15,13 @@ const Work = () => {
           <p className='text-4xl font-bold inline border-b-4 text-gray-300 border-pink-600'>
             Work
           </p>
-          <p className='py-6'>// Check out some of my recent work</p>
+          <p className='py-6'>{"// Check out some of my recent work"}</p>
         </div>
 
 {/* container for projects */}
 <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
           
-          {/* Grid Item */}
+          {/* Grd Item */}
           {project.map((item, index) => (
   <div
     key={index}

--- a/src/components/Work.jsx
+++ b/src/components/Work.jsx
@@ -21,7 +21,7 @@ const Work = () => {
 {/* container for projects */}
 <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
           
-          {/* Gird Item */}
+          {/* Grid Item */}
           {project.map((item, index) => (
   <div
     key={index}


### PR DESCRIPTION
  - Commit 1 (fix):
        Changed "gird item" to "grid item" to fix a spelling mistake.

  - Commit 2 (feat):
        Enclosed text containing // in curly braces {} to comply with eslint regulations.

  - Commit 3 (fix):
        Removed the "Image" keyword from the navbar logo as it was in violation of eslint rules.